### PR TITLE
pylint should only check for errors

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -22,4 +22,3 @@ jobs:
     - name: Analysing the code with pylint
       run: |
         pylint -E $(git ls-files '*.py')
-        pylint $(git ls-files '*.py')


### PR DESCRIPTION
Leave only the '-E' pylint call. 